### PR TITLE
Add Jest and tests for handleApiRequest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,16 @@
+import type {Config} from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleNameMapper: {
+    '^@api/(.*)$': '<rootDir>/src/modules/api/$1',
+    '^@ui/(.*)$': '<rootDir>/src/modules/ui/$1',
+    '^@shared/(.*)$': '<rootDir>/src/modules/shared/$1',
+    '^@prisma/(.*)$': '<rootDir>/prisma/$1',
+    '^@lib/(.*)$': '<rootDir>/lib/$1'
+  }
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@prisma/client": "^6.12.0",
@@ -22,6 +23,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
     "prisma": "^6.12.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.0"
   }
 }

--- a/src/modules/api/utils/handle-api-request.test.ts
+++ b/src/modules/api/utils/handle-api-request.test.ts
@@ -1,0 +1,26 @@
+import {handleApiRequest} from './handle-api-request'
+import {UsersNotFoundError} from '../errors/users-not-found.error'
+
+describe('handleApiRequest', () => {
+  it('resolves successful callback', async () => {
+    const res = await handleApiRequest(async () => ({foo: 'bar'}))
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({foo: 'bar'})
+  })
+
+  it('handles HttpError responses', async () => {
+    const res = await handleApiRequest(() => {
+      throw new UsersNotFoundError()
+    })
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({error: 'Users not found'})
+  })
+
+  it('handles generic errors', async () => {
+    const res = await handleApiRequest(() => {
+      throw new Error('boom')
+    })
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({error: 'Internal Server Error'})
+  })
+})


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest
- add test script and dependencies
- test handleApiRequest utility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f77f7a40c832f809bb6c0a0d7a37a