### PR TITLE
Replace text loader with animated spinner

### DIFF
--- a/src/app/ui/hello-world/page.tsx
+++ b/src/app/ui/hello-world/page.tsx
@@ -3,6 +3,7 @@ import styles from './page.module.css'
 import {useState} from 'react';
 import Title from "@ui/components/common/atoms/Title";
 import UsersList from "@ui/components/users/molecules/UsersList";
+import Loader from "@ui/components/common/atoms/Loader";
 import {UserModelDto} from "@shared/dto/models/user.model.dto";
 import {UserGateway} from "@ui/gateways/user.gateway";
 import {GetAllUsersResponseDto} from "@shared/dto/responses/get-all-users.response.dto";
@@ -23,7 +24,7 @@ export default function HelloWorldPage() {
         <div className={styles.container}>
             <Title label="Hello world!"/>
             <p>Here we display the list of users: </p>
-            {loading && <span className="loading">Loading...</span>}
+            {loading && <Loader />}
             {error && <span className="error">{error}</span>}
             <UsersList users={users}/>
         </div>

--- a/src/modules/ui/components/common/atoms/Loader.module.css
+++ b/src/modules/ui/components/common/atoms/Loader.module.css
@@ -1,0 +1,17 @@
+.loader {
+    width: 24px;
+    height: 24px;
+    border: 4px solid rgba(0, 0, 0, 0.1);
+    border-top-color: rgba(0, 0, 0, 0.7);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/modules/ui/components/common/atoms/Loader.tsx
+++ b/src/modules/ui/components/common/atoms/Loader.tsx
@@ -1,0 +1,5 @@
+import styles from './Loader.module.css'
+
+export default function Loader() {
+    return <span className={styles.loader} aria-label="Loading" />
+}


### PR DESCRIPTION
## Summary
- add an animated Loader component
- use Loader in HelloWorld page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7a625720832f81c2962e2a61b97b